### PR TITLE
feat(Prescription) : Added Apis from DailyMed , and Updated prescription methods 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/src/main/java/com/leo/pillpathbackend/config/DailyMedConfig.java
+++ b/src/main/java/com/leo/pillpathbackend/config/DailyMedConfig.java
@@ -1,0 +1,30 @@
+package com.leo.pillpathbackend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class DailyMedConfig {
+
+    @Value("${dailymed.base-url:https://dailymed.nlm.nih.gov/dailymed/services/v2}")
+    private String baseUrl;
+
+    @Bean
+    public WebClient dailyMedClient() {
+        // Increase buffer size if large labels
+        ExchangeStrategies strategies = ExchangeStrategies.builder()
+                .codecs(cfg -> cfg.defaultCodecs().maxInMemorySize(2 * 1024 * 1024)) // 2MB
+                .build();
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .exchangeStrategies(strategies)
+                .build();
+    }
+}
+

--- a/src/main/java/com/leo/pillpathbackend/config/SecurityConfig.java
+++ b/src/main/java/com/leo/pillpathbackend/config/SecurityConfig.java
@@ -70,6 +70,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/pharmacy-admin/**").permitAll()
                         .requestMatchers("/api/pharmacy-admin/**").permitAll()
                         .requestMatchers("/api/v1/prescriptions/**").permitAll()
+                        .requestMatchers("/api/v1/medicines/**").permitAll()
+
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/leo/pillpathbackend/controller/MedicineController.java
+++ b/src/main/java/com/leo/pillpathbackend/controller/MedicineController.java
@@ -1,0 +1,63 @@
+package com.leo.pillpathbackend.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.leo.pillpathbackend.dto.ApiResponse;
+import com.leo.pillpathbackend.dto.dailymed.DailyMedMediaResponse;
+import com.leo.pillpathbackend.dto.dailymed.DailyMedSplPage;
+import com.leo.pillpathbackend.service.DailyMedService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/v1/medicines")
+@RequiredArgsConstructor
+public class MedicineController {
+
+    private final DailyMedService dailyMedService;
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<Map<String,Object>>> search(
+            @RequestParam String name,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new IllegalArgumentException("Parameter 'name' is required");
+        }
+        DailyMedSplPage result = dailyMedService.searchByDrugName(name.trim(), page, size);
+        List<Map<String,Object>> items = result.getResults() == null ? List.of() : result.getResults().stream().map(s -> {
+            Map<String,Object> m = new HashMap<>();
+            m.put("setId", s.getSetid());
+            m.put("title", s.getTitle());
+            m.put("effectiveTime", s.getEffective_time());
+            m.put("version", s.getVersion());
+            return m;
+        }).collect(Collectors.toList());
+        Map<String,Object> payload = new HashMap<>();
+        payload.put("items", items);
+        payload.put("page", Map.of(
+                "page", page,
+                "size", size,
+                "total", result.getTotal()
+        ));
+        return ResponseEntity.ok(ApiResponse.success(payload, "Search successful"));
+    }
+
+    @GetMapping("/{setId}/label")
+    public ResponseEntity<ApiResponse<JsonNode>> getLabel(@PathVariable String setId) {
+        JsonNode label = dailyMedService.getLabel(setId);
+        return ResponseEntity.ok(ApiResponse.success(label, "Label fetched"));
+    }
+
+    @GetMapping("/{setId}/media")
+    public ResponseEntity<ApiResponse<DailyMedMediaResponse>> getMedia(@PathVariable String setId) {
+        DailyMedMediaResponse media = dailyMedService.getMedia(setId);
+        return ResponseEntity.ok(ApiResponse.success(media, "Media fetched"));
+    }
+}
+

--- a/src/main/java/com/leo/pillpathbackend/controller/PrescriptionController.java
+++ b/src/main/java/com/leo/pillpathbackend/controller/PrescriptionController.java
@@ -5,6 +5,7 @@ import com.leo.pillpathbackend.dto.PrescriptionItemDTO;
 import com.leo.pillpathbackend.dto.PrescriptionListItemDTO;
 import com.leo.pillpathbackend.dto.request.CreatePrescriptionRequest;
 import com.leo.pillpathbackend.dto.activity.PrescriptionActivityListResponse;
+import com.leo.pillpathbackend.dto.PharmacistSubmissionItemsDTO;
 import com.leo.pillpathbackend.entity.PharmacistUser;
 import com.leo.pillpathbackend.repository.UserRepository;
 import com.leo.pillpathbackend.service.PrescriptionService;
@@ -228,6 +229,77 @@ public class PrescriptionController {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    // Pharmacist: list items in a submission (order preview)
+    @GetMapping("/pharmacist/submissions/{submissionId}/items")
+    public ResponseEntity<?> getSubmissionItems(@PathVariable Long submissionId, HttpServletRequest request) {
+        try {
+            Long pharmacistId = auth.extractPharmacistIdFromRequest(request);
+            PharmacistSubmissionItemsDTO dto = prescriptionService.getSubmissionItems(pharmacistId, submissionId);
+            return ResponseEntity.ok(dto);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    // Pharmacist: add an item
+    @PostMapping("/pharmacist/submissions/{submissionId}/items")
+    public ResponseEntity<?> addSubmissionItem(@PathVariable Long submissionId,
+                                               @RequestBody PrescriptionItemDTO item,
+                                               HttpServletRequest request) {
+        try {
+            Long pharmacistId = auth.extractPharmacistIdFromRequest(request);
+            PharmacistSubmissionItemsDTO dto = prescriptionService.addSubmissionItem(pharmacistId, submissionId, item);
+            return ResponseEntity.ok(dto);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    // Pharmacist: update an item
+    @PutMapping("/pharmacist/submissions/{submissionId}/items/{itemId}")
+    public ResponseEntity<?> updateSubmissionItem(@PathVariable Long submissionId,
+                                                  @PathVariable Long itemId,
+                                                  @RequestBody PrescriptionItemDTO item,
+                                                  HttpServletRequest request) {
+        try {
+            Long pharmacistId = auth.extractPharmacistIdFromRequest(request);
+            PharmacistSubmissionItemsDTO dto = prescriptionService.updateSubmissionItem(pharmacistId, submissionId, itemId, item);
+            return ResponseEntity.ok(dto);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    // Pharmacist: remove an item
+    @DeleteMapping("/pharmacist/submissions/{submissionId}/items/{itemId}")
+    public ResponseEntity<?> deleteSubmissionItem(@PathVariable Long submissionId,
+                                                  @PathVariable Long itemId,
+                                                  HttpServletRequest request) {
+        try {
+            Long pharmacistId = auth.extractPharmacistIdFromRequest(request);
+            PharmacistSubmissionItemsDTO dto = prescriptionService.removeSubmissionItem(pharmacistId, submissionId, itemId);
+            return ResponseEntity.ok(dto);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", e.getMessage()));
         }

--- a/src/main/java/com/leo/pillpathbackend/dto/PharmacistQueueItemDTO.java
+++ b/src/main/java/com/leo/pillpathbackend/dto/PharmacistQueueItemDTO.java
@@ -1,0 +1,23 @@
+package com.leo.pillpathbackend.dto;
+
+import com.leo.pillpathbackend.entity.enums.PrescriptionStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PharmacistQueueItemDTO {
+    private Long submissionId;          // per-pharmacy submission (routing) id
+    private String prescriptionCode;    // shared code across pharmacies
+    private String uploadedAt;          // ISO timestamp
+    private PrescriptionStatus status;  // submission status
+    private String imageUrl;            // image
+    private String note;                // note provided by customer
+    private Boolean claimed;            // whether claimed by a pharmacist
+    private Long assignedPharmacistId;  // who claimed
+}
+

--- a/src/main/java/com/leo/pillpathbackend/dto/PharmacistResponseDTO.java
+++ b/src/main/java/com/leo/pillpathbackend/dto/PharmacistResponseDTO.java
@@ -1,6 +1,6 @@
 package com.leo.pillpathbackend.dto;
 
-import com.leo.pillpathbackend.entity.Pharmacist;
+import com.leo.pillpathbackend.entity.PharmacistUser;
 import com.leo.pillpathbackend.entity.enums.EmploymentStatus;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -35,34 +35,31 @@ public class PharmacistResponseDTO {
     private List<String> certifications = new ArrayList<>();
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private Long pharmacistUserId;
 
-    public void setUserId(Long pharmacistUserId) {
-        this.pharmacistUserId = pharmacistUserId;
-    }
-
-    public Long getUserId() {
-        return pharmacistUserId;
-    }
-
-    public PharmacistResponseDTO(Pharmacist pharmacist) {
-        this.id = pharmacist.getId();
-        this.fullName = pharmacist.getFullName();
-        this.email = pharmacist.getEmail();
-        this.phoneNumber = pharmacist.getPhoneNumber();
-        this.dateOfBirth = pharmacist.getDateOfBirth();
-        this.profilePictureUrl = pharmacist.getProfilePictureUrl();
-        this.licenseNumber = pharmacist.getLicenseNumber();
-        this.licenseExpiryDate = pharmacist.getLicenseExpiryDate();
-        this.specialization = pharmacist.getSpecialization();
-        this.yearsOfExperience = pharmacist.getYearsOfExperience();
-        this.hireDate = pharmacist.getHireDate();
-        this.shiftSchedule = pharmacist.getShiftSchedule();
-        this.certifications = pharmacist.getCertifications();
-        this.isActive = pharmacist.getIsActive();
-        this.isVerified = pharmacist.getIsVerified();
-        this.employmentStatus = pharmacist.getEmploymentStatus();
-        this.createdAt = pharmacist.getCreatedAt();
-        this.updatedAt = pharmacist.getUpdatedAt();
+    public static PharmacistResponseDTO fromEntity(PharmacistUser u) {
+        PharmacistResponseDTO dto = new PharmacistResponseDTO();
+        dto.id = u.getId();
+        dto.fullName = u.getFullName();
+        dto.email = u.getEmail();
+        dto.phoneNumber = u.getPhoneNumber();
+        dto.dateOfBirth = u.getDateOfBirth();
+        dto.profilePictureUrl = u.getProfilePictureUrl();
+        if (u.getPharmacy() != null) {
+            dto.pharmacyId = u.getPharmacy().getId();
+            dto.pharmacyName = u.getPharmacy().getName();
+        }
+        dto.licenseNumber = u.getLicenseNumber();
+        dto.licenseExpiryDate = u.getLicenseExpiryDate();
+        dto.specialization = u.getSpecialization();
+        dto.yearsOfExperience = u.getYearsOfExperience();
+        dto.hireDate = u.getHireDate();
+        dto.isActive = u.getIsActive();
+        dto.isVerified = u.getIsVerified();
+        dto.employmentStatus = u.getEmploymentStatus();
+        dto.shiftSchedule = u.getShiftSchedule();
+        dto.certifications = u.getCertifications() != null ? u.getCertifications() : new ArrayList<>();
+        dto.createdAt = u.getCreatedAt();
+        dto.updatedAt = u.getUpdatedAt();
+        return dto;
     }
 }

--- a/src/main/java/com/leo/pillpathbackend/dto/PharmacistSubmissionItemsDTO.java
+++ b/src/main/java/com/leo/pillpathbackend/dto/PharmacistSubmissionItemsDTO.java
@@ -1,0 +1,23 @@
+package com.leo.pillpathbackend.dto;
+
+import com.leo.pillpathbackend.entity.enums.PrescriptionStatus;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PharmacistSubmissionItemsDTO {
+    private Long submissionId;
+    private String prescriptionCode;
+    private Long pharmacyId;
+    private PrescriptionStatus status;
+    private BigDecimal totalPrice; // aggregated from items
+    private boolean editable; // whether current pharmacist can edit items
+    private List<PrescriptionItemDTO> items;
+}
+

--- a/src/main/java/com/leo/pillpathbackend/dto/dailymed/DailyMedMediaResponse.java
+++ b/src/main/java/com/leo/pillpathbackend/dto/dailymed/DailyMedMediaResponse.java
@@ -1,0 +1,26 @@
+package com.leo.pillpathbackend.dto.dailymed;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DailyMedMediaResponse {
+
+    @JsonProperty("data")
+    private List<MediaItem> data;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class MediaItem {
+        private String type;          // e.g. image, pdf
+        private String url;           // media URL
+        private String title;         // optional
+        @JsonProperty("thumbnail")
+        private String thumbnailUrl;  // optional
+    }
+}
+

--- a/src/main/java/com/leo/pillpathbackend/dto/dailymed/DailyMedSplPage.java
+++ b/src/main/java/com/leo/pillpathbackend/dto/dailymed/DailyMedSplPage.java
@@ -1,0 +1,44 @@
+package com.leo.pillpathbackend.dto.dailymed;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DailyMedSplPage {
+
+    @JsonProperty("data")
+    private List<DailyMedSplSummaryDTO> results;
+
+    // DailyMed response contains paging metadata in "metadata" or "meta" depending on endpoint
+    @JsonProperty("metadata")
+    private Meta meta; // will be null if not present
+
+    @JsonProperty("meta")
+    private Meta metaAlt; // fallback name
+
+    public int getTotal() {
+        Meta m = meta != null ? meta : metaAlt;
+        return m != null && m.getTotal() != null ? m.getTotal() : (results != null ? results.size() : 0);
+    }
+
+    public Integer getCurrentPage() {
+        Meta m = meta != null ? meta : metaAlt;
+        return m != null ? m.getCurrentPage() : null;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Meta {
+        @JsonProperty("current_page")
+        private Integer currentPage;
+        @JsonProperty("total")
+        private Integer total;
+        @JsonProperty("pagesize")
+        private Integer pageSize;
+    }
+}
+

--- a/src/main/java/com/leo/pillpathbackend/dto/dailymed/DailyMedSplSummaryDTO.java
+++ b/src/main/java/com/leo/pillpathbackend/dto/dailymed/DailyMedSplSummaryDTO.java
@@ -1,0 +1,14 @@
+package com.leo.pillpathbackend.dto.dailymed;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DailyMedSplSummaryDTO {
+    private String setid;          // SPL Set ID
+    private String title;          // Product title
+    private String effective_time; // Effective date/time string
+    private String version;        // Version number as string
+}
+

--- a/src/main/java/com/leo/pillpathbackend/entity/Order.java
+++ b/src/main/java/com/leo/pillpathbackend/entity/Order.java
@@ -38,9 +38,9 @@ public class Order {
     @JoinColumn(name = "prescription_id")
     private Prescription prescription;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "processed_by")
-    private Pharmacist processedBy;
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "processed_by")
+//    private Pharmacist processedBy;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "order_type")

--- a/src/main/java/com/leo/pillpathbackend/entity/Pharmacist.java
+++ b/src/main/java/com/leo/pillpathbackend/entity/Pharmacist.java
@@ -1,3 +1,6 @@
+// DEPRECATED: Legacy Pharmacist entity replaced by PharmacistUser.
+// Keeping file to avoid dangling references during refactor. Do not use.
+/*
 package com.leo.pillpathbackend.entity;
 import com.leo.pillpathbackend.entity.enums.EmploymentStatus;
 import com.leo.pillpathbackend.entity.enums.UserType;
@@ -122,3 +125,4 @@ public class Pharmacist {
         return pharmacistUser != null ? pharmacistUser.getPhoneNumber() : null;
     }
 }
+*/

--- a/src/main/java/com/leo/pillpathbackend/entity/PharmacistUser.java
+++ b/src/main/java/com/leo/pillpathbackend/entity/PharmacistUser.java
@@ -2,18 +2,25 @@
 package com.leo.pillpathbackend.entity;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.leo.pillpathbackend.entity.enums.EmploymentStatus;
 import com.leo.pillpathbackend.entity.enums.UserType;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @DiscriminatorValue("PHARMACIST")
@@ -31,7 +38,7 @@ public class PharmacistUser extends User {
     @JoinColumn(name = "pharmacy_id")
     private Pharmacy pharmacy;
     
-    @Column(name = "license_number")
+    @Column(name = "license_number", unique = true)
     private String licenseNumber;
     
     @Column(name = "license_expiry_date")
@@ -49,11 +56,17 @@ public class PharmacistUser extends User {
     @Column(name = "shift_schedule")
     private String shiftSchedule;
     
-    @Column(name = "certifications")
-    private String certifications;
-    
+    // change to JSON array
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "certifications", columnDefinition = "jsonb")
+    private List<String> certifications = new ArrayList<>();
+
     @Column(name = "is_verified")
     private Boolean isVerified;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "employment_status")
+    private EmploymentStatus employmentStatus = EmploymentStatus.ACTIVE;
 
     public Pharmacy getPharmacy() {
         return pharmacy;
@@ -105,10 +118,10 @@ public void setShiftSchedule(String shiftSchedule) {
     this.shiftSchedule = shiftSchedule;
 }
 
-public String getCertifications() {
+public List<String> getCertifications() {
     return certifications;
 }
-public void setCertifications(String certifications) {
+public void setCertifications(List<String> certifications) {
     this.certifications = certifications;
 }
 
@@ -118,4 +131,12 @@ public Boolean getIsVerified() {
 public void setIsVerified(Boolean isVerified) {
     this.isVerified = isVerified;
 }
+
+public EmploymentStatus getEmploymentStatus() {
+        return employmentStatus;
+    }
+
+    public void setEmploymentStatus(EmploymentStatus employmentStatus) {
+        this.employmentStatus = employmentStatus;
+    }
 }

--- a/src/main/java/com/leo/pillpathbackend/entity/Pharmacy.java
+++ b/src/main/java/com/leo/pillpathbackend/entity/Pharmacy.java
@@ -98,9 +98,9 @@ public class Pharmacy {
     // Relationships
     @OneToMany(mappedBy = "pharmacy", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<PharmacyAdmin> pharmacyAdmins = new ArrayList<>();
-
-    @OneToMany(mappedBy = "pharmacy", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<Pharmacist> pharmacists = new ArrayList<>();
+//
+//    @OneToMany(mappedBy = "pharmacy", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+//    private List<Pharmacist> pharmacists = new ArrayList<>();
 
     @OneToMany(mappedBy = "pharmacy", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Order> orders = new ArrayList<>();

--- a/src/main/java/com/leo/pillpathbackend/repository/PharmacistRepository.java
+++ b/src/main/java/com/leo/pillpathbackend/repository/PharmacistRepository.java
@@ -1,3 +1,5 @@
+// DEPRECATED: Legacy PharmacistRepository removed after consolidating to PharmacistUser.
+/*
 package com.leo.pillpathbackend.repository;
 
 import com.leo.pillpathbackend.entity.Pharmacist;
@@ -68,3 +70,4 @@ public interface PharmacistRepository extends JpaRepository<Pharmacist, Long> {
     @Query("SELECT p FROM Pharmacist p WHERE p.pharmacy.id = :pharmacyId AND p.isActive = true AND p.licenseExpiryDate < :date")
     List<Pharmacist> findByPharmacyIdAndLicenseExpiringSoon(@Param("pharmacyId") Long pharmacyId, @Param("date") LocalDate date);
 }
+*/

--- a/src/main/java/com/leo/pillpathbackend/repository/PharmacistUserRepository.java
+++ b/src/main/java/com/leo/pillpathbackend/repository/PharmacistUserRepository.java
@@ -1,0 +1,37 @@
+package com.leo.pillpathbackend.repository;
+
+import com.leo.pillpathbackend.entity.PharmacistUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PharmacistUserRepository extends JpaRepository<PharmacistUser, Long> {
+
+    List<PharmacistUser> findByPharmacyIdAndIsActiveTrue(Long pharmacyId);
+    List<PharmacistUser> findByPharmacyId(Long pharmacyId);
+
+    boolean existsByEmail(String email);
+    boolean existsByLicenseNumber(String licenseNumber);
+    Optional<PharmacistUser> findByEmail(String email);
+    Optional<PharmacistUser> findByLicenseNumber(String licenseNumber);
+
+    boolean existsByIdAndPharmacyIdAndIsActiveTrue(Long id, Long pharmacyId);
+    long countByPharmacyIdAndIsActiveTrue(Long pharmacyId);
+
+    @Query("SELECT p FROM PharmacistUser p WHERE p.pharmacy.id = :pharmacyId AND p.isActive = true AND (" +
+            "LOWER(p.fullName) LIKE LOWER(CONCAT('%', :term, '%')) OR " +
+            "LOWER(p.email) LIKE LOWER(CONCAT('%', :term, '%')) OR " +
+            "LOWER(p.licenseNumber) LIKE LOWER(CONCAT('%', :term, '%')) OR " +
+            "LOWER(p.specialization) LIKE LOWER(CONCAT('%', :term, '%')))" )
+    List<PharmacistUser> search(@Param("pharmacyId") Long pharmacyId, @Param("term") String term);
+
+    @Query("SELECT p FROM PharmacistUser p WHERE p.pharmacy.id = :pharmacyId AND p.isActive = true AND p.licenseExpiryDate < :date")
+    List<PharmacistUser> findByPharmacyIdAndLicenseExpiringSoon(@Param("pharmacyId") Long pharmacyId, @Param("date") LocalDate date);
+}
+

--- a/src/main/java/com/leo/pillpathbackend/repository/PrescriptionSubmissionItemRepository.java
+++ b/src/main/java/com/leo/pillpathbackend/repository/PrescriptionSubmissionItemRepository.java
@@ -1,0 +1,8 @@
+package com.leo.pillpathbackend.repository;
+
+import com.leo.pillpathbackend.entity.PrescriptionSubmissionItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PrescriptionSubmissionItemRepository extends JpaRepository<PrescriptionSubmissionItem, Long> {
+}
+

--- a/src/main/java/com/leo/pillpathbackend/service/DailyMedService.java
+++ b/src/main/java/com/leo/pillpathbackend/service/DailyMedService.java
@@ -1,0 +1,12 @@
+package com.leo.pillpathbackend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.leo.pillpathbackend.dto.dailymed.DailyMedMediaResponse;
+import com.leo.pillpathbackend.dto.dailymed.DailyMedSplPage;
+
+public interface DailyMedService {
+    DailyMedSplPage searchByDrugName(String name, int page, int size);
+    DailyMedMediaResponse getMedia(String setId);
+    JsonNode getLabel(String setId);
+}
+

--- a/src/main/java/com/leo/pillpathbackend/service/PrescriptionService.java
+++ b/src/main/java/com/leo/pillpathbackend/service/PrescriptionService.java
@@ -31,4 +31,13 @@ public interface PrescriptionService {
     List<PharmacistQueueItemDTO> getPharmacistQueue(Long pharmacistId, PrescriptionStatus status);
 
     PharmacistQueueItemDTO claimSubmission(Long pharmacistId, Long submissionId);
+
+    // Pharmacist per-submission item management (order preview building)
+    com.leo.pillpathbackend.dto.PharmacistSubmissionItemsDTO getSubmissionItems(Long pharmacistId, Long submissionId);
+
+    com.leo.pillpathbackend.dto.PharmacistSubmissionItemsDTO addSubmissionItem(Long pharmacistId, Long submissionId, PrescriptionItemDTO itemDTO);
+
+    com.leo.pillpathbackend.dto.PharmacistSubmissionItemsDTO updateSubmissionItem(Long pharmacistId, Long submissionId, Long itemId, PrescriptionItemDTO itemDTO);
+
+    com.leo.pillpathbackend.dto.PharmacistSubmissionItemsDTO removeSubmissionItem(Long pharmacistId, Long submissionId, Long itemId);
 }

--- a/src/main/java/com/leo/pillpathbackend/service/PrescriptionService.java
+++ b/src/main/java/com/leo/pillpathbackend/service/PrescriptionService.java
@@ -5,6 +5,8 @@ import com.leo.pillpathbackend.dto.PrescriptionItemDTO;
 import com.leo.pillpathbackend.dto.PrescriptionListItemDTO;
 import com.leo.pillpathbackend.dto.activity.PrescriptionActivityListResponse;
 import com.leo.pillpathbackend.dto.request.CreatePrescriptionRequest;
+import com.leo.pillpathbackend.dto.PharmacistQueueItemDTO;
+import com.leo.pillpathbackend.entity.enums.PrescriptionStatus;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -24,4 +26,9 @@ public interface PrescriptionService {
     PrescriptionDTO replaceItemsForPharmacy(Long pharmacyId, Long prescriptionId, List<PrescriptionItemDTO> items);
 
     PrescriptionActivityListResponse getCustomerActivities(Long customerId, int page, int size);
+
+    // Pharmacist queue (multi-pharmacy submissions)
+    List<PharmacistQueueItemDTO> getPharmacistQueue(Long pharmacistId, PrescriptionStatus status);
+
+    PharmacistQueueItemDTO claimSubmission(Long pharmacistId, Long submissionId);
 }

--- a/src/main/java/com/leo/pillpathbackend/service/impl/DailyMedServiceImpl.java
+++ b/src/main/java/com/leo/pillpathbackend/service/impl/DailyMedServiceImpl.java
@@ -1,0 +1,78 @@
+package com.leo.pillpathbackend.service.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.leo.pillpathbackend.dto.dailymed.DailyMedMediaResponse;
+import com.leo.pillpathbackend.dto.dailymed.DailyMedSplPage;
+import com.leo.pillpathbackend.service.DailyMedService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DailyMedServiceImpl implements DailyMedService {
+
+    private final WebClient dailyMedClient;
+
+    @Override
+    public DailyMedSplPage searchByDrugName(String name, int page, int size) {
+        try {
+            return dailyMedClient.get()
+                    .uri(uri -> uri.path("/spls.json")
+                            .queryParam("drug_name", name)
+                            .queryParam("name_type", "both")
+                            .queryParam("pagesize", size)
+                            .queryParam("page", page)
+                            .build())
+                    .retrieve()
+                    .onStatus(status -> status.is4xxClientError(), resp -> resp.createException().map(ex -> {
+                        log.warn("DailyMed 4xx search error: {}", ex.getMessage());
+                        return new RuntimeException("DailyMed search error: " + ex.getMessage());
+                    }))
+                    .onStatus(status -> status.is5xxServerError(), resp -> resp.createException().map(ex -> {
+                        log.error("DailyMed 5xx search error: {}", ex.getMessage());
+                        return new RuntimeException("DailyMed service unavailable");
+                    }))
+                    .bodyToMono(DailyMedSplPage.class)
+                    .block();
+        } catch (WebClientResponseException e) {
+            throw new RuntimeException("DailyMed search failed: " + e.getStatusCode());
+        } catch (Exception e) {
+            throw new RuntimeException("DailyMed search unexpected error");
+        }
+    }
+
+    @Override
+    public DailyMedMediaResponse getMedia(String setId) {
+        try {
+            return dailyMedClient.get()
+                    .uri("/spls/{setid}/media.json", setId)
+                    .retrieve()
+                    .onStatus(status -> status.is4xxClientError(), resp -> resp.createException().map(ex -> new RuntimeException("Media not found")))
+                    .onStatus(status -> status.is5xxServerError(), resp -> resp.createException().map(ex -> new RuntimeException("DailyMed service unavailable")))
+                    .bodyToMono(DailyMedMediaResponse.class)
+                    .block();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to fetch media");
+        }
+    }
+
+    @Override
+    public JsonNode getLabel(String setId) {
+        try {
+            return dailyMedClient.get()
+                    .uri("/spls/{setid}.json", setId)
+                    .retrieve()
+                    .onStatus(status -> status.is4xxClientError(), resp -> resp.createException().map(ex -> new RuntimeException("Label not found")))
+                    .onStatus(status -> status.is5xxServerError(), resp -> resp.createException().map(ex -> new RuntimeException("DailyMed service unavailable")))
+                    .bodyToMono(JsonNode.class)
+                    .block();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to fetch label");
+        }
+    }
+}

--- a/src/main/java/com/leo/pillpathbackend/service/impl/PharmacistServiceImpl.java
+++ b/src/main/java/com/leo/pillpathbackend/service/impl/PharmacistServiceImpl.java
@@ -3,15 +3,14 @@ package com.leo.pillpathbackend.service.impl;
 import com.leo.pillpathbackend.dto.PharmacistCreateRequestDTO;
 import com.leo.pillpathbackend.dto.PharmacistUpdateRequestDTO;
 import com.leo.pillpathbackend.dto.PharmacistResponseDTO;
-import com.leo.pillpathbackend.entity.Pharmacist;
 import com.leo.pillpathbackend.entity.PharmacistUser;
 import com.leo.pillpathbackend.entity.Pharmacy;
 import com.leo.pillpathbackend.entity.enums.EmploymentStatus;
-import com.leo.pillpathbackend.repository.PharmacistRepository;
+import com.leo.pillpathbackend.repository.PharmacistUserRepository;
 import com.leo.pillpathbackend.repository.PharmacyRepository;
 import com.leo.pillpathbackend.repository.UserRepository;
-import com.leo.pillpathbackend.service.PharmacistService;
 import com.leo.pillpathbackend.service.CloudinaryService;
+import com.leo.pillpathbackend.service.PharmacistService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,194 +26,86 @@ import java.util.stream.Collectors;
 @Slf4j
 @Transactional
 public class PharmacistServiceImpl implements PharmacistService {
-    
-    private final PharmacistRepository pharmacistRepository;
+
+    private final PharmacistUserRepository pharmacistUserRepository;
     private final PharmacyRepository pharmacyRepository;
-    private final UserRepository userRepository;
+    private final UserRepository userRepository; // for email existence
     private final PasswordEncoder passwordEncoder;
     private final CloudinaryService cloudinaryService;
 
     @Override
-    @Transactional
     public PharmacistResponseDTO createPharmacist(PharmacistCreateRequestDTO request) {
-        log.info("Creating new pharmacist with email: {}", request.getEmail());
-        log.info("Full request: {}", request);
-        
-        // Validate required fields
-        if (request.getEmail() == null || request.getEmail().trim().isEmpty()) {
-            throw new RuntimeException("Email is required");
-        }
-        if (request.getFullName() == null || request.getFullName().trim().isEmpty()) {
-            throw new RuntimeException("Full name is required");
-        }
-        if (request.getLicenseNumber() == null || request.getLicenseNumber().trim().isEmpty()) {
-            throw new RuntimeException("License number is required");
-        }
-        if (request.getPassword() == null || request.getPassword().trim().isEmpty()) {
-            throw new RuntimeException("Password is required");
-        }
-        if (request.getPharmacyId() == null) {
-            throw new RuntimeException("Pharmacy ID is required");
-        }
-        
-        // Validate email uniqueness in User table
-        if (userRepository.existsByEmail(request.getEmail().trim())) {
-            throw new RuntimeException("Email already exists: " + request.getEmail());
-        }
+        log.info("Creating new pharmacist (user) with email: {}", request.getEmail());
 
-        // Validate license number uniqueness
-        if (pharmacistRepository.existsByLicenseNumber(request.getLicenseNumber().trim())) {
-            throw new RuntimeException("License number already exists: " + request.getLicenseNumber());
-        }
+        // Basic validation
+        if (request.getEmail() == null || request.getEmail().isBlank()) throw new RuntimeException("Email is required");
+        if (request.getFullName() == null || request.getFullName().isBlank()) throw new RuntimeException("Full name is required");
+        if (request.getLicenseNumber() == null || request.getLicenseNumber().isBlank()) throw new RuntimeException("License number is required");
+        if (request.getPassword() == null || request.getPassword().isBlank()) throw new RuntimeException("Password is required");
+        if (request.getPharmacyId() == null) throw new RuntimeException("Pharmacy ID is required");
 
-        // Get pharmacy
+        if (userRepository.existsByEmail(request.getEmail().trim())) throw new RuntimeException("Email already exists: " + request.getEmail());
+        if (pharmacistUserRepository.existsByLicenseNumber(request.getLicenseNumber().trim())) throw new RuntimeException("License number already exists: " + request.getLicenseNumber());
+
         Pharmacy pharmacy = pharmacyRepository.findById(request.getPharmacyId())
                 .orElseThrow(() -> new RuntimeException("Pharmacy not found with ID: " + request.getPharmacyId()));
 
-        // Create PharmacistUser first (for login capability)
         PharmacistUser user = new PharmacistUser();
         user.setEmail(request.getEmail().trim());
-        user.setUsername(request.getEmail().trim()); // Use email as username
+        user.setUsername(request.getEmail().trim());
         user.setPassword(passwordEncoder.encode(request.getPassword()));
         user.setFullName(request.getFullName().trim());
         user.setPhoneNumber(request.getPhoneNumber() != null ? request.getPhoneNumber().trim() : null);
         user.setDateOfBirth(request.getDateOfBirth());
         user.setProfilePictureUrl(request.getProfilePictureUrl());
-        user.setIsActive(true);
-        user.setEmailVerified(false);
-        user.setPhoneVerified(false);
+        user.setIsActive(request.getIsActive() != null ? request.getIsActive() : true);
+        user.setIsVerified(request.getIsVerified() != null ? request.getIsVerified() : false);
+        user.setPharmacy(pharmacy);
+        user.setLicenseNumber(request.getLicenseNumber().trim());
+        user.setLicenseExpiryDate(request.getLicenseExpiryDate());
+        user.setSpecialization(request.getSpecialization());
+        user.setYearsOfExperience(request.getYearsOfExperience());
+        user.setHireDate(request.getHireDate() != null ? request.getHireDate() : LocalDate.now());
+        user.setShiftSchedule(request.getShiftSchedule());
+        user.setCertifications(request.getCertifications());
+        user.setEmploymentStatus(request.getEmploymentStatus() != null ? request.getEmploymentStatus() : EmploymentStatus.ACTIVE);
 
-        // Save user first
-        PharmacistUser savedUser = (PharmacistUser) userRepository.save(user);
-        log.info("Created user with ID: {}", savedUser.getId());
-
-        // Create Pharmacist entity
-        Pharmacist pharmacist = new Pharmacist();
-        
-        // Set BOTH the direct fields (required by entity) AND the relationship
-        // Direct fields (to satisfy nullable = false constraints)
-        pharmacist.setEmail(request.getEmail().trim());
-        pharmacist.setPassword(passwordEncoder.encode(request.getPassword()));
-        pharmacist.setFullName(request.getFullName().trim());
-        pharmacist.setPhoneNumber(request.getPhoneNumber() != null ? request.getPhoneNumber().trim() : null);
-        pharmacist.setDateOfBirth(request.getDateOfBirth());
-        pharmacist.setProfilePictureUrl(request.getProfilePictureUrl());
-        
-        // Set the PharmacistUser relationship
-        pharmacist.setPharmacistUser(savedUser);
-        
-        // Set pharmacy relationship
-        pharmacist.setPharmacy(pharmacy);
-        
-        // Set pharmacist-specific fields
-        pharmacist.setLicenseNumber(request.getLicenseNumber().trim());
-        pharmacist.setLicenseExpiryDate(request.getLicenseExpiryDate());
-        pharmacist.setSpecialization(request.getSpecialization() != null ? request.getSpecialization().trim() : null);
-        pharmacist.setYearsOfExperience(request.getYearsOfExperience());
-        pharmacist.setHireDate(request.getHireDate() != null ? request.getHireDate() : LocalDate.now());
-        pharmacist.setShiftSchedule(request.getShiftSchedule());
-        pharmacist.setCertifications(request.getCertifications());
-        pharmacist.setIsActive(request.getIsActive() != null ? request.getIsActive() : true);
-        pharmacist.setIsVerified(request.getIsVerified() != null ? request.getIsVerified() : false);
-        pharmacist.setEmploymentStatus(request.getEmploymentStatus() != null ? request.getEmploymentStatus() : EmploymentStatus.ACTIVE);
-
-        Pharmacist savedPharmacist = pharmacistRepository.save(pharmacist);
-        log.info("Created pharmacist with ID: {}", savedPharmacist.getId());
-
-        return convertToResponse(savedPharmacist);
+        PharmacistUser saved = pharmacistUserRepository.save(user);
+        return PharmacistResponseDTO.fromEntity(saved);
     }
 
     @Override
-    @Transactional
     public PharmacistResponseDTO updatePharmacist(Long pharmacistId, PharmacistUpdateRequestDTO request) {
-        log.info("Updating pharmacist with ID: {}", pharmacistId);
-        
-        Pharmacist pharmacist = pharmacistRepository.findById(pharmacistId)
+        PharmacistUser user = pharmacistUserRepository.findById(pharmacistId)
                 .orElseThrow(() -> new RuntimeException("Pharmacist not found with ID: " + pharmacistId));
 
-        // Update BOTH direct fields and PharmacistUser fields
-        PharmacistUser user = pharmacist.getPharmacistUser();
-        
-        if (request.getFullName() != null && !request.getFullName().trim().isEmpty()) {
-            // Update both direct field and user field
-            pharmacist.setFullName(request.getFullName().trim());
-            if (user != null) {
-                user.setFullName(request.getFullName().trim());
-            }
-        }
-        
-        if (request.getPhoneNumber() != null) {
-            // Update both direct field and user field
-            pharmacist.setPhoneNumber(request.getPhoneNumber().trim());
-            if (user != null) {
-                user.setPhoneNumber(request.getPhoneNumber().trim());
-            }
-        }
-        
-        if (request.getDateOfBirth() != null) {
-            // Update both direct field and user field
-            pharmacist.setDateOfBirth(request.getDateOfBirth());
-            if (user != null) {
-                user.setDateOfBirth(request.getDateOfBirth());
-            }
-        }
-        
-        if (request.getProfilePictureUrl() != null) {
-            // Update both direct field and user field
-            pharmacist.setProfilePictureUrl(request.getProfilePictureUrl());
-            if (user != null) {
-                user.setProfilePictureUrl(request.getProfilePictureUrl());
-            }
-        }
-        
-        // Update pharmacist-specific data
-        if (request.getLicenseExpiryDate() != null) {
-            pharmacist.setLicenseExpiryDate(request.getLicenseExpiryDate());
-        }
-        if (request.getSpecialization() != null) {
-            pharmacist.setSpecialization(request.getSpecialization().trim());
-        }
-        if (request.getYearsOfExperience() != null) {
-            pharmacist.setYearsOfExperience(request.getYearsOfExperience());
-        }
-        if (request.getShiftSchedule() != null) {
-            pharmacist.setShiftSchedule(request.getShiftSchedule());
-        }
-        if (request.getCertifications() != null) {
-            pharmacist.setCertifications(request.getCertifications());
-        }
+        if (request.getFullName() != null && !request.getFullName().isBlank()) user.setFullName(request.getFullName().trim());
+        if (request.getPhoneNumber() != null) user.setPhoneNumber(request.getPhoneNumber().trim());
+        if (request.getDateOfBirth() != null) user.setDateOfBirth(request.getDateOfBirth());
+        if (request.getProfilePictureUrl() != null) user.setProfilePictureUrl(request.getProfilePictureUrl());
+        if (request.getLicenseExpiryDate() != null) user.setLicenseExpiryDate(request.getLicenseExpiryDate());
+        if (request.getSpecialization() != null) user.setSpecialization(request.getSpecialization());
+        if (request.getYearsOfExperience() != null) user.setYearsOfExperience(request.getYearsOfExperience());
+        if (request.getShiftSchedule() != null) user.setShiftSchedule(request.getShiftSchedule());
+        if (request.getCertifications() != null) user.setCertifications(request.getCertifications());
 
-        // Save the updated user first if it exists
-        if (user != null) {
-            userRepository.save(user);
-        }
-
-        Pharmacist savedPharmacist = pharmacistRepository.save(pharmacist);
-        log.info("Updated pharmacist with ID: {}", savedPharmacist.getId());
-
-        return convertToResponse(savedPharmacist);
+        PharmacistUser saved = pharmacistUserRepository.save(user);
+        return PharmacistResponseDTO.fromEntity(saved);
     }
 
     @Override
     @Transactional(readOnly = true)
     public PharmacistResponseDTO getPharmacistById(Long pharmacistId) {
-        log.info("Fetching pharmacist with ID: {}", pharmacistId);
-        
-        Pharmacist pharmacist = pharmacistRepository.findById(pharmacistId)
+        return pharmacistUserRepository.findById(pharmacistId)
+                .map(PharmacistResponseDTO::fromEntity)
                 .orElseThrow(() -> new RuntimeException("Pharmacist not found with ID: " + pharmacistId));
-        
-        return convertToResponse(pharmacist);
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<PharmacistResponseDTO> getPharmacistsByPharmacyId(Long pharmacyId) {
-        log.info("Fetching pharmacists for pharmacy ID: {}", pharmacyId);
-        
-        List<Pharmacist> pharmacists = pharmacistRepository.findByPharmacyIdAndIsActiveTrue(pharmacyId);
-        return pharmacists.stream()
-                .map(this::convertToResponse)
-                .collect(Collectors.toList());
+        return pharmacistUserRepository.findByPharmacyIdAndIsActiveTrue(pharmacyId)
+                .stream().map(PharmacistResponseDTO::fromEntity).collect(Collectors.toList());
     }
 
     @Override
@@ -226,190 +117,58 @@ public class PharmacistServiceImpl implements PharmacistService {
     @Override
     @Transactional(readOnly = true)
     public List<PharmacistResponseDTO> searchPharmacistsByPharmacyId(Long pharmacyId, String searchTerm) {
-        log.info("Searching pharmacists for pharmacy ID: {} with term: {}", pharmacyId, searchTerm);
-        
-        if (searchTerm == null || searchTerm.trim().isEmpty()) {
-            return getPharmacistsByPharmacyId(pharmacyId);
-        }
-        
-        List<Pharmacist> pharmacists = pharmacistRepository.searchByPharmacyIdAndTerm(pharmacyId, searchTerm.trim());
-        return pharmacists.stream()
-                .map(this::convertToResponse)
-                .collect(Collectors.toList());
+        if (searchTerm == null || searchTerm.isBlank()) return getPharmacistsByPharmacyId(pharmacyId);
+        return pharmacistUserRepository.search(pharmacyId, searchTerm.trim())
+                .stream().map(PharmacistResponseDTO::fromEntity).collect(Collectors.toList());
     }
 
     @Override
-    @Transactional
     public void deletePharmacist(Long pharmacistId) {
-        log.info("Deleting pharmacist with ID: {}", pharmacistId);
-        
-        Pharmacist pharmacist = pharmacistRepository.findById(pharmacistId)
+        PharmacistUser user = pharmacistUserRepository.findById(pharmacistId)
                 .orElseThrow(() -> new RuntimeException("Pharmacist not found with ID: " + pharmacistId));
-        
-        // Soft delete pharmacist
-        pharmacist.setIsActive(false);
-        pharmacist.setEmploymentStatus(EmploymentStatus.TERMINATED);
-        
-        // Also deactivate the associated user
-        PharmacistUser user = pharmacist.getPharmacistUser();
-        if (user != null) {
-            user.setIsActive(false);
-            userRepository.save(user);
-        }
-        
-        pharmacistRepository.save(pharmacist);
-        log.info("Soft deleted pharmacist with ID: {}", pharmacistId);
+        // soft delete
+        user.setIsActive(false);
+        user.setEmploymentStatus(EmploymentStatus.TERMINATED);
+        pharmacistUserRepository.save(user);
     }
 
     @Override
-    @Transactional
     public PharmacistResponseDTO togglePharmacistStatus(Long pharmacistId, Boolean isActive) {
-        log.info("Toggling status for pharmacist ID: {} to: {}", pharmacistId, isActive);
-        
-        Pharmacist pharmacist = pharmacistRepository.findById(pharmacistId)
+        PharmacistUser user = pharmacistUserRepository.findById(pharmacistId)
                 .orElseThrow(() -> new RuntimeException("Pharmacist not found with ID: " + pharmacistId));
-        
-        // Update pharmacist status
-        pharmacist.setIsActive(isActive);
-        if (isActive) {
-            pharmacist.setEmploymentStatus(EmploymentStatus.ACTIVE);
-        } else {
-            pharmacist.setEmploymentStatus(EmploymentStatus.INACTIVE);
-        }
-        
-        // Update associated user status
-        PharmacistUser user = pharmacist.getPharmacistUser();
-        if (user != null) {
-            user.setIsActive(isActive);
-            userRepository.save(user);
-        }
-        
-        Pharmacist savedPharmacist = pharmacistRepository.save(pharmacist);
-        log.info("Updated pharmacist status with ID: {}", savedPharmacist.getId());
-        
-        return convertToResponse(savedPharmacist);
+        user.setIsActive(isActive);
+        user.setEmploymentStatus(Boolean.TRUE.equals(isActive) ? EmploymentStatus.ACTIVE : EmploymentStatus.INACTIVE);
+        PharmacistUser saved = pharmacistUserRepository.save(user);
+        return PharmacistResponseDTO.fromEntity(saved);
     }
 
     @Override
     @Transactional(readOnly = true)
     public long getPharmacistCountByPharmacyId(Long pharmacyId) {
-        log.info("Getting pharmacist count for pharmacy ID: {}", pharmacyId);
-        return pharmacistRepository.countByPharmacyIdAndIsActiveTrue(pharmacyId);
+        return pharmacistUserRepository.countByPharmacyIdAndIsActiveTrue(pharmacyId);
     }
 
     @Override
     @Transactional(readOnly = true)
     public boolean isPharmacistInPharmacy(Long pharmacistId, Long pharmacyId) {
-        log.info("Verifying if pharmacist {} belongs to pharmacy {}", pharmacistId, pharmacyId);
-        return pharmacistRepository.existsByIdAndPharmacyIdAndIsActiveTrue(pharmacistId, pharmacyId);
-    }
-
-    // Helper method to convert Pharmacist entity to PharmacistResponseDTO
-    private PharmacistResponseDTO convertToResponse(Pharmacist pharmacist) {
-        PharmacistResponseDTO response = new PharmacistResponseDTO();
-        response.setId(pharmacist.getId());
-        
-        // Use direct fields for now (since they're required by the entity)
-        response.setFullName(pharmacist.getFullName());
-        response.setEmail(pharmacist.getEmail());
-        response.setPhoneNumber(pharmacist.getPhoneNumber());
-        response.setDateOfBirth(pharmacist.getDateOfBirth());
-        response.setProfilePictureUrl(pharmacist.getProfilePictureUrl());
-        
-        // Set pharmacy data
-        if (pharmacist.getPharmacy() != null) {
-            response.setPharmacyId(pharmacist.getPharmacy().getId());
-            response.setPharmacyName(pharmacist.getPharmacy().getName());
-        }
-        
-        // Set pharmacist-specific data
-        response.setLicenseNumber(pharmacist.getLicenseNumber());
-        response.setLicenseExpiryDate(pharmacist.getLicenseExpiryDate());
-        response.setSpecialization(pharmacist.getSpecialization());
-        response.setYearsOfExperience(pharmacist.getYearsOfExperience());
-        response.setHireDate(pharmacist.getHireDate());
-        response.setIsActive(pharmacist.getIsActive());
-        response.setIsVerified(pharmacist.getIsVerified());
-        response.setEmploymentStatus(pharmacist.getEmploymentStatus());
-        response.setShiftSchedule(pharmacist.getShiftSchedule());
-        response.setCertifications(pharmacist.getCertifications());
-        response.setCreatedAt(pharmacist.getCreatedAt());
-        response.setUpdatedAt(pharmacist.getUpdatedAt());
-        
-        return response;
+        return pharmacistUserRepository.existsByIdAndPharmacyIdAndIsActiveTrue(pharmacistId, pharmacyId);
     }
 
     @Override
-    @Transactional
     public PharmacistResponseDTO updateProfilePicture(Long pharmacistId, String imageUrl) {
-        log.info("Updating profile picture for pharmacist ID: {}", pharmacistId);
-
-        Pharmacist pharmacist = pharmacistRepository.findById(pharmacistId)
+        PharmacistUser user = pharmacistUserRepository.findById(pharmacistId)
                 .orElseThrow(() -> new RuntimeException("Pharmacist not found with ID: " + pharmacistId));
-
-        // Delete old profile picture from Cloudinary if exists
-        String oldProfilePictureUrl = pharmacist.getProfilePictureUrl();
-        if (oldProfilePictureUrl != null && !oldProfilePictureUrl.isEmpty()) {
-            try {
-                String publicId = cloudinaryService.extractPublicIdFromUrl(oldProfilePictureUrl);
-                if (publicId != null) {
-                    cloudinaryService.deleteImage(publicId);
-                }
-            } catch (Exception e) {
-                log.warn("Failed to delete old profile picture: {}", e.getMessage());
-                // Don't fail the operation if old image deletion fails
-            }
-        }
-
-        // Update both direct field and user field
-        pharmacist.setProfilePictureUrl(imageUrl);
-
-        PharmacistUser user = pharmacist.getPharmacistUser();
-        if (user != null) {
-            user.setProfilePictureUrl(imageUrl);
-            userRepository.save(user);
-        }
-
-        Pharmacist savedPharmacist = pharmacistRepository.save(pharmacist);
-        log.info("Updated profile picture for pharmacist ID: {}", pharmacistId);
-
-        return convertToResponse(savedPharmacist);
+        user.setProfilePictureUrl(imageUrl);
+        PharmacistUser saved = pharmacistUserRepository.save(user);
+        return PharmacistResponseDTO.fromEntity(saved);
     }
 
     @Override
-    @Transactional
     public PharmacistResponseDTO removeProfilePicture(Long pharmacistId) {
-        log.info("Removing profile picture for pharmacist ID: {}", pharmacistId);
-
-        Pharmacist pharmacist = pharmacistRepository.findById(pharmacistId)
+        PharmacistUser user = pharmacistUserRepository.findById(pharmacistId)
                 .orElseThrow(() -> new RuntimeException("Pharmacist not found with ID: " + pharmacistId));
-
-        // Delete profile picture from Cloudinary if exists
-        String profilePictureUrl = pharmacist.getProfilePictureUrl();
-        if (profilePictureUrl != null && !profilePictureUrl.isEmpty()) {
-            try {
-                String publicId = cloudinaryService.extractPublicIdFromUrl(profilePictureUrl);
-                if (publicId != null) {
-                    cloudinaryService.deleteImage(publicId);
-                }
-            } catch (Exception e) {
-                log.warn("Failed to delete profile picture from Cloudinary: {}", e.getMessage());
-                // Don't fail the operation if image deletion fails
-            }
-        }
-
-        // Remove profile picture URLs
-        pharmacist.setProfilePictureUrl(null);
-
-        PharmacistUser user = pharmacist.getPharmacistUser();
-        if (user != null) {
-            user.setProfilePictureUrl(null);
-            userRepository.save(user);
-        }
-
-        Pharmacist savedPharmacist = pharmacistRepository.save(pharmacist);
-        log.info("Removed profile picture for pharmacist ID: {}", pharmacistId);
-
-        return convertToResponse(savedPharmacist);
+        user.setProfilePictureUrl(null);
+        PharmacistUser saved = pharmacistUserRepository.save(user);
+        return PharmacistResponseDTO.fromEntity(saved);
     }
 }

--- a/src/main/java/com/leo/pillpathbackend/service/impl/PrescriptionServiceImpl.java
+++ b/src/main/java/com/leo/pillpathbackend/service/impl/PrescriptionServiceImpl.java
@@ -483,7 +483,7 @@ public class PrescriptionServiceImpl implements PrescriptionService {
     }
 
     private String generateCode() {
-        return "RX-" + java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
-                + "-" + java.util.UUID.randomUUID().toString().substring(0, 6).toUpperCase();
+        return "RX-" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+                + "-" + UUID.randomUUID().toString().substring(0, 6).toUpperCase();
     }
 }

--- a/src/main/java/com/leo/pillpathbackend/util/Mapper.java
+++ b/src/main/java/com/leo/pillpathbackend/util/Mapper.java
@@ -426,15 +426,11 @@ public class Mapper {
         }
         PharmacistProfileDTO dto = new PharmacistProfileDTO();
         dto.setId(pharmacist.getId());
-        //dto.setUsername(pharmacist.getUsername());
         dto.setEmail(pharmacist.getEmail());
         dto.setFullName(pharmacist.getFullName());
         dto.setPhoneNumber(pharmacist.getPhoneNumber());
         dto.setDateOfBirth(pharmacist.getDateOfBirth());
-        //dto.setAddress(pharmacist.getAddress());
         dto.setProfilePictureUrl(pharmacist.getProfilePictureUrl());
-
-        // Pharmacist specific fields
         if (pharmacist.getPharmacy() != null) {
             dto.setPharmacyId(pharmacist.getPharmacy().getId());
             dto.setPharmacyName(pharmacist.getPharmacy().getName());
@@ -445,12 +441,9 @@ public class Mapper {
         dto.setYearsOfExperience(pharmacist.getYearsOfExperience());
         dto.setHireDate(pharmacist.getHireDate());
         dto.setShiftSchedule(pharmacist.getShiftSchedule());
-        dto.setCertifications(Collections.singletonList(pharmacist.getCertifications()));
+        dto.setCertifications(pharmacist.getCertifications());
         dto.setIsVerified(pharmacist.getIsVerified());
         dto.setIsActive(pharmacist.getIsActive());
-
-        // dto.setEmailVerified(pharmacist.getEmailVerified());
-        // dto.setPhoneVerified(pharmacist.getPhoneVerified());
         return dto;
     }
 


### PR DESCRIPTION
This pull request introduces several new features and refactors related to pharmacist workflow and medicine information integration. The main changes include new endpoints for pharmacists to manage prescription submissions, integration with the DailyMed API for medicine data, and DTO/model updates to support these features.

**Pharmacist workflow enhancements:**

* Added multiple endpoints in `PrescriptionController` for pharmacists to view their queue, claim submissions, and manage prescription items (view, add, update, delete). These endpoints facilitate the pharmacist's workflow for handling customer prescriptions.

* Introduced `PharmacistQueueItemDTO` and `PharmacistSubmissionItemsDTO` to structure pharmacist queue and submission item data, supporting the new controller endpoints. [[1]](diffhunk://#diff-353ff206613108f385b61c946456e898571f0f2f22d1fb91a8665df94e337253R1-R23) [[2]](diffhunk://#diff-22c6fe8c8b1292611926be2dd756e26c57e0ceda02e52e69bd34c48621480513R1-R23)

* Refactored `PharmacistResponseDTO` to use `PharmacistUser` instead of the deprecated `Pharmacist` entity, and updated its construction logic accordingly. [[1]](diffhunk://#diff-8d38905ac615828f7847425838574c0bad2256ce3c67d8f069e94fa93c3a7699L3-R3) [[2]](diffhunk://#diff-8d38905ac615828f7847425838574c0bad2256ce3c67d8f069e94fa93c3a7699L38-R63)

**Medicine/DailyMed integration:**

* Added `MedicineController` with endpoints to search for medicines, fetch SPL labels, and retrieve related media, using the DailyMed API.

* Introduced DTOs for DailyMed API responses: `DailyMedSplPage`, `DailyMedSplSummaryDTO`, and `DailyMedMediaResponse` to parse and structure the external data. [[1]](diffhunk://#diff-0104cfcb760e70f466c9017c3159acca0381eaaf303f6491ec5d2d2c0356061fR1-R44) [[2]](diffhunk://#diff-b4d94abdb6465da293ef9aae2f390493ecdb174429d6f10aeb80cbcfedbbd6dfR1-R14) [[3]](diffhunk://#diff-b575a0155afe35b131395a813f735f51f6650a9e609c20ad23e8211ba2e63374R1-R26)

* Added `DailyMedConfig` to configure a `WebClient` bean for accessing the DailyMed API.

**Security and dependency updates:**

* Updated Spring Security configuration to allow unauthenticated access to the new `/api/v1/medicines/**` endpoints.

* Added `spring-boot-starter-webflux` dependency in `pom.xml` to support reactive web client for DailyMed integration.

**Model/entity changes:**

* Deprecated the legacy `Pharmacist` entity in favor of `PharmacistUser`, with clear comments to avoid its usage. [[1]](diffhunk://#diff-31ce99234c273c9cc322c815f1c870ba81f9bf14254b852cf7b3ac71deb5f161R1-R3) [[2]](diffhunk://#diff-31ce99234c273c9cc322c815f1c870ba81f9bf14254b852cf7b3ac71deb5f161R128)

* Removed the reference to the old `Pharmacist` entity in the `Order` model, commenting out the `processedBy` field.