### PR TITLE
Back tanu

### DIFF
--- a/src/main/HttpReq/HttpReq.http
+++ b/src/main/HttpReq/HttpReq.http
@@ -132,3 +132,13 @@ Authorization: Bearer {{authToken}}
 Content-Type: multipart/form-data
 
 file=@C:\Users\ASUS\Downloads\pharmacy-logo.jpg;type=image/jpeg
+### Create a moderator user (accessed by admin)
+
+POST http://localhost:8080/api/v1/users/moderators
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJwaWxscGF0aCIsImlhdCI6MTc1NjYzMzQ2NywiZXhwIjoxNzU2NzE5ODY3LCJzdWIiOiIxIiwidWlkIjoxLCJyb2xlIjoiQURNSU4ifQ.rg48WQIrOi58CEWCzBizd7XUfXulKu3U370QCIFpokw
+Content-Type: application/json
+
+{
+  "username": "mod1",
+  "password": "pass123"
+}

--- a/src/main/java/com/leo/pillpathbackend/config/SecurityConfig.java
+++ b/src/main/java/com/leo/pillpathbackend/config/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/pharmacies/**").permitAll()
                         .requestMatchers("/api/v1/pharmacy-admin/**").permitAll()
                         .requestMatchers("/api/pharmacy-admin/**").permitAll()
+
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/com/leo/pillpathbackend/controller/AdminController.java
+++ b/src/main/java/com/leo/pillpathbackend/controller/AdminController.java
@@ -1,20 +1,19 @@
+// PillPath-Backend/src/main/java/com/leo/pillpathbackend/controller/AdminController.java
 package com.leo.pillpathbackend.controller;
 
+import com.leo.pillpathbackend.dto.AddAnnouncementResponse;
 import com.leo.pillpathbackend.dto.AdminDashboardResponseDTO;
+import com.leo.pillpathbackend.dto.AddAnnouncementRequest;
+import com.leo.pillpathbackend.dto.AddModeratorRequest;
+import com.leo.pillpathbackend.entity.Announcement;
 import com.leo.pillpathbackend.service.AdminService;
+import com.leo.pillpathbackend.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import com.leo.pillpathbackend.dto.AddAnnouncementRequest;
-import com.leo.pillpathbackend.dto.AddAnnouncementResponse;
-import com.leo.pillpathbackend.entity.Announcement;
-import com.leo.pillpathbackend.service.AdminService;
-import org.springframework.web.bind.annotation.*;
-import jakarta.validation.Valid;
-
 import java.util.List;
-
 
 @RestController
 @RequestMapping("/api/v1/admin")
@@ -23,13 +22,12 @@ import java.util.List;
 public class AdminController {
 
     private final AdminService adminService;
-
+    private final UserService userService;
 
     @GetMapping("/dashboard")
     public ResponseEntity<AdminDashboardResponseDTO> getDashboardData() {
         try {
-            AdminDashboardResponseDTO dashboardData = adminService.getDashboardData();
-            return ResponseEntity.ok(dashboardData);
+            return ResponseEntity.ok(adminService.getDashboardData());
         } catch (Exception e) {
             return ResponseEntity.internalServerError().build();
         }
@@ -44,18 +42,15 @@ public class AdminController {
 
     @GetMapping("/announcements")
     public ResponseEntity<List<Announcement>> getAllAnnouncements() {
-        List<Announcement> announcements = adminService.getAllAnnouncementsLatestFirst();
-        return ResponseEntity.ok(announcements);
+        return ResponseEntity.ok(adminService.getAllAnnouncementsLatestFirst());
     }
 
     @PutMapping("/announcements/{id}")
     public ResponseEntity<Announcement> updateAnnouncement(
             @PathVariable Long id,
             @Valid @RequestBody AddAnnouncementRequest request) {
-
         try {
-            Announcement updatedAnnouncement = adminService.updateAnnouncement(id, request);
-            return ResponseEntity.ok(updatedAnnouncement);
+            return ResponseEntity.ok(adminService.updateAnnouncement(id, request));
         } catch (RuntimeException e) {
             return ResponseEntity.notFound().build();
         }
@@ -64,8 +59,7 @@ public class AdminController {
     @PatchMapping("/announcements/{id}/toggle-status")
     public ResponseEntity<Announcement> toggleAnnouncementStatus(@PathVariable Long id) {
         try {
-            Announcement updatedAnnouncement = adminService.toggleAnnouncementStatus(id);
-            return ResponseEntity.ok(updatedAnnouncement);
+            return ResponseEntity.ok(adminService.toggleAnnouncementStatus(id));
         } catch (RuntimeException e) {
             return ResponseEntity.notFound().build();
         }
@@ -81,14 +75,10 @@ public class AdminController {
         }
     }
 
-
-
-
-
-
-
-    // Future admin endpoints:
-    // @GetMapping("/users")
-    // @PostMapping("/users/{id}/deactivate")
-    // etc.
+    // New endpoint: add moderator under admin controller
+    @PostMapping("/moderators")
+    public ResponseEntity<AddModeratorRequest> addModerator(@RequestBody AddModeratorRequest request) {
+        AddModeratorRequest created = userService.addModerator(request);
+        return ResponseEntity.ok(created);
+    }
 }

--- a/src/main/java/com/leo/pillpathbackend/controller/UserController.java
+++ b/src/main/java/com/leo/pillpathbackend/controller/UserController.java
@@ -56,6 +56,14 @@ public class UserController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
         }
     }
+
+    @PostMapping("/moderators")
+    public ResponseEntity<AddModeratorRequest> addModerator(@RequestBody AddModeratorRequest request) {
+        AddModeratorRequest created = userService.addModerator(request);
+        return ResponseEntity.ok(created);
+    }
+
+
     @PostMapping("/logout")
     public ResponseEntity<Map<String, Object>> logout(HttpServletRequest request) {
         Map<String, Object> response = new HashMap<>();

--- a/src/main/java/com/leo/pillpathbackend/dto/AddModeratorRequest.java
+++ b/src/main/java/com/leo/pillpathbackend/dto/AddModeratorRequest.java
@@ -1,0 +1,9 @@
+package com.leo.pillpathbackend.dto;
+
+import lombok.Data;
+
+@Data
+public class AddModeratorRequest {
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/leo/pillpathbackend/entity/Admin.java
+++ b/src/main/java/com/leo/pillpathbackend/entity/Admin.java
@@ -7,6 +7,7 @@ import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +30,8 @@ public class Admin extends User {
     @Enumerated(EnumType.STRING)
     @Column(name = "admin_level")
     private AdminLevel adminLevel = AdminLevel.STANDARD;
+    @Column(name = "hire_date")
+    private LocalDate hireDate;
 
     @Column(name = "last_login")
     private LocalDateTime lastLogin;

--- a/src/main/java/com/leo/pillpathbackend/entity/enums/AdminLevel.java
+++ b/src/main/java/com/leo/pillpathbackend/entity/enums/AdminLevel.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum AdminLevel {
     STANDARD("Standard Admin"),
     SUPER("Super Admin"),
-    SYSTEM("System Admin");
+    SYSTEM("System Admin"),
+    MODERATOR("Moderator Admin");
 
     private final String displayName;
 

--- a/src/main/java/com/leo/pillpathbackend/service/UserService.java
+++ b/src/main/java/com/leo/pillpathbackend/service/UserService.java
@@ -14,4 +14,7 @@ public interface UserService {
     AdminLoginResponse loginAdmin(AdminLoginRequest request);
     UnifiedLoginResponse unifiedLogin(UnifiedLoginRequest request);
     void logout(String token);
+
+    AddModeratorRequest addModerator(AddModeratorRequest request);
+
 }

--- a/src/main/java/com/leo/pillpathbackend/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/leo/pillpathbackend/service/impl/UserServiceImpl.java
@@ -12,8 +12,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import com.leo.pillpathbackend.entity.enums.AdminLevel;
 
 import java.util.Date;
+import java.time.LocalDate;
 import java.util.Optional;
 
 @Service
@@ -205,6 +207,19 @@ public class UserServiceImpl implements UserService {
                 .adminLevel(admin.getAdminLevel().name())
                 .token(token)
                 .build();
+    }
+
+    //add moderator
+    @Override
+    public AddModeratorRequest addModerator(AddModeratorRequest request) {
+        Admin moderator = new Admin();
+        moderator.setUsername(request.getUsername());
+        moderator.setPassword(passwordEncoder.encode(request.getPassword()));
+        moderator.setAdminLevel(AdminLevel.MODERATOR);
+        moderator.setHireDate(LocalDate.now());
+        // Set other required fields if needed
+        userRepository.save(moderator);
+        return request;
     }
 
     public void logout(String token) {


### PR DESCRIPTION
This pull request introduces functionality for admin users to create moderator accounts, along with related backend changes to support this feature. The changes include a new DTO for moderator creation, updates to the `Admin` entity and `AdminLevel` enum, service methods, and new endpoints in both the admin and user controllers.

**Moderator Creation Feature:**

* Added `AddModeratorRequest` DTO to encapsulate moderator creation data (`username`, `password`).
* Updated `Admin` entity to include a `hireDate` field and support the new `MODERATOR` admin level in the `AdminLevel` enum. [[1]](diffhunk://#diff-3dddeed133e8b2d8d473558f871ae485d535416b26e0b7b0aa2267ce6d5ac525R33-R34) [[2]](diffhunk://#diff-cd32203858503cb36491f40a3443829829a0a76e7d8cb0486d28b152da0cea2eL9-R10)
* Implemented `addModerator` method in `UserService` and its implementation, allowing admins to create moderators with encoded passwords and current hire date. [[1]](diffhunk://#diff-42c2c58703ca18c95ded301363b2dc33209a3accd37d51f3a43adac52e35665eR17-R19) [[2]](diffhunk://#diff-fd5c1c57994c3946f55cd9120f84ff822aa022478653ef4ae65412d0b4026d49R212-R224)

**API and Controller Updates:**

* Added `/moderators` POST endpoints to both `AdminController` and `UserController` for moderator creation, delegating to the new service method. [[1]](diffhunk://#diff-d249547f6c3be82752555238257f6e4bda1205c9432ad035b79e0acbbb76eaf1L83-R87) [[2]](diffhunk://#diff-5c868ace4465bc828e75d5004a42423eccda3089ff84a6a03ecf36451e333e50R59-R66)
* Added an example HTTP request for creating a moderator user in the API request file.

**Minor Improvements and Cleanups:**

* Refactored methods in `AdminController` for conciseness and consistency in response handling. [[1]](diffhunk://#diff-d249547f6c3be82752555238257f6e4bda1205c9432ad035b79e0acbbb76eaf1R1-R34) [[2]](diffhunk://#diff-d249547f6c3be82752555238257f6e4bda1205c9432ad035b79e0acbbb76eaf1L46-R57) [[3]](diffhunk://#diff-d249547f6c3be82752555238257f6e4bda1205c9432ad035b79e0acbbb76eaf1L66-R66)
* Minor import and formatting updates for clarity and maintainability. [[1]](diffhunk://#diff-3dddeed133e8b2d8d473558f871ae485d535416b26e0b7b0aa2267ce6d5ac525R10) [[2]](diffhunk://#diff-fd5c1c57994c3946f55cd9120f84ff822aa022478653ef4ae65412d0b4026d49R15-R18)

These changes collectively enable admins to create moderator accounts via the API and ensure the backend is structured to support this new user role.