### PR TITLE
Comment out countByPharmacyIdAndStatus query

### DIFF
--- a/src/main/java/com/leo/pillpathbackend/repository/PharmacyOrderRepository.java
+++ b/src/main/java/com/leo/pillpathbackend/repository/PharmacyOrderRepository.java
@@ -56,6 +56,6 @@ public interface PharmacyOrderRepository extends JpaRepository<PharmacyOrder, Lo
     Optional<PharmacyOrder> findByOrderCodeAndCustomerOrder_Customer_Id(String orderCode, Long customerId);
 
     // Count fulfilled (delivered) orders all-time for a pharmacy
-    @Query("SELECT COALESCE(COUNT(po), 0) FROM PharmacyOrder po WHERE po.pharmacy.id = :pharmacyId AND po.status = :status")
-    long countByPharmacyIdAndStatus(@Param("pharmacyId") Long pharmacyId, @Param("status") PharmacyOrderStatus status);
+//    @Query("SELECT COALESCE(COUNT(po), 0) FROM PharmacyOrder po WHERE po.pharmacy.id = :pharmacyId AND po.status = :status")
+//    long countByPharmacyIdAndStatus(@Param("pharmacyId") Long pharmacyId, @Param("status") PharmacyOrderStatus status);
 }


### PR DESCRIPTION
This pull request makes a minor change by commenting out the `countByPharmacyIdAndStatus` query method in the `PharmacyOrderRepository` interface. No other functional code changes are included.The custom query and method for counting orders by pharmacy ID and status have been commented out, possibly for deprecation or debugging purposes. No functional code changes were made.